### PR TITLE
Wire team page to Notion members API

### DIFF
--- a/apps/portal/app/team/page.tsx
+++ b/apps/portal/app/team/page.tsx
@@ -3,9 +3,10 @@
 import React from 'react';
 import Image from 'next/image';
 import TeamDisplay from '@/components/organisms/landingPage/TeamDisplay/TeamDisplay';
-import { techPlusTeamMembers } from '@/components/organisms/landingPage/about/config';
+import { useMembers } from '@/lib/hooks/useMembers';
 
 export default function TeamPage() {
+  const { members, isLoading, error } = useMembers();
   const leftLeafPath = "/assets/images/left-leaf-portal.svg";
   const rightLeafPath = "/assets/images/right-leaf-portal.svg";
 
@@ -58,9 +59,7 @@ export default function TeamPage() {
             We are a dedicated group of students who work toward the common goal of
             building the tech community at UW for you
           </p>
-          <div className="grid grid-cols-1 gap-2">
-            <TeamDisplay league={techPlusTeamMembers} />
-          </div>
+          <TeamDisplay members={members} isLoading={isLoading} error={error} />
         </div>
       </div>
     </div>

--- a/apps/portal/components/organisms/landingPage/TeamDisplay/MemberCard.tsx
+++ b/apps/portal/components/organisms/landingPage/TeamDisplay/MemberCard.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import { Avatar, Chip } from '@mui/material';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import EmailIcon from '@mui/icons-material/Email';
+import type { MemberData } from '@/lib/repositories/memberRepository';
+
+interface MemberCardProps {
+  member: MemberData;
+}
+
+export default function MemberCard({ member }: MemberCardProps) {
+  const initials = member.name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="flex flex-col items-center bg-white rounded-lg border border-gray-100 shadow-sm p-6 hover:shadow-md transition-shadow">
+      <div className="mb-4">
+        {member.photo_url ? (
+          <div className="w-24 h-24 rounded-full overflow-hidden ring-2 ring-[#8BC677]/40">
+            <Image
+              src={member.photo_url}
+              alt={member.name}
+              width={96}
+              height={96}
+              className="w-full h-full object-cover"
+              unoptimized
+            />
+          </div>
+        ) : (
+          <Avatar
+            sx={{
+              width: 96,
+              height: 96,
+              bgcolor: '#6C9A5C',
+              fontSize: '1.5rem',
+              fontWeight: 600,
+            }}
+          >
+            {initials}
+          </Avatar>
+        )}
+      </div>
+
+      <h3 className="text-base font-semibold text-[#020B2C] text-center leading-tight">
+        {member.name}
+      </h3>
+
+      {member.role && (
+        <p className="text-sm text-[#6C9A5C] font-medium text-center mt-1">{member.role}</p>
+      )}
+
+      {member.teams.length > 0 && (
+        <div className="flex flex-wrap justify-center gap-1 mt-3">
+          {member.teams.map((team) => (
+            <Chip
+              key={team}
+              label={team}
+              size="small"
+              sx={{
+                backgroundColor: 'rgba(108, 154, 92, 0.12)',
+                color: '#4a7a3c',
+                fontSize: '0.7rem',
+                height: '22px',
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      {(member.linkedin || member.email) && (
+        <div className="flex gap-3 mt-4">
+          {member.linkedin && (
+            <a
+              href={member.linkedin}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`${member.name} LinkedIn`}
+              className="text-[#6C9A5C] hover:text-[#4a7a3c] transition-colors"
+            >
+              <LinkedInIcon fontSize="small" />
+            </a>
+          )}
+          {member.email && (
+            <a
+              href={`mailto:${member.email}`}
+              aria-label={`Email ${member.name}`}
+              className="text-[#6C9A5C] hover:text-[#4a7a3c] transition-colors"
+            >
+              <EmailIcon fontSize="small" />
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/portal/components/organisms/landingPage/TeamDisplay/TeamDisplay.tsx
+++ b/apps/portal/components/organisms/landingPage/TeamDisplay/TeamDisplay.tsx
@@ -1,15 +1,71 @@
 'use client';
 
 import React from 'react';
+import { CircularProgress } from '@mui/material';
+import type { MemberData } from '@/lib/repositories/memberRepository';
+import MemberCard from './MemberCard';
 
 interface TeamDisplayProps {
-  league: any[];
+  members: MemberData[];
+  isLoading: boolean;
+  error: string | null;
 }
 
-export default function TeamDisplay({ league }: TeamDisplayProps) {
+function groupByDepartment(members: MemberData[]): [string, MemberData[]][] {
+  const map = new Map<string, MemberData[]>();
+  for (const member of members) {
+    const dept = member.department ?? 'Other';
+    if (!map.has(dept)) map.set(dept, []);
+    map.get(dept)!.push(member);
+  }
+  return [...map.entries()].sort(([a], [b]) => {
+    if (a === 'Other') return 1;
+    if (b === 'Other') return -1;
+    return a.localeCompare(b);
+  });
+}
+
+export default function TeamDisplay({ members, isLoading, error }: TeamDisplayProps) {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-20">
+        <CircularProgress sx={{ color: '#6C9A5C' }} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-20 text-gray-500">
+        <p>Unable to load team members. Please try again later.</p>
+      </div>
+    );
+  }
+
+  if (members.length === 0) {
+    return (
+      <div className="text-center py-20 text-gray-500">
+        <p>No team members found.</p>
+      </div>
+    );
+  }
+
+  const groups = groupByDepartment(members);
+
   return (
-    <div className="text-center">
-      <p className="text-gray-600">Team Display - {league.length} members</p>
+    <div className="space-y-12 text-left">
+      {groups.map(([department, deptMembers]) => (
+        <section key={department}>
+          <h2 className="text-2xl font-semibold text-[#020B2C] mb-6 pb-2 border-b border-[#8BC677]/40">
+            {department}
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+            {deptMembers.map((member) => (
+              <MemberCard key={member.id} member={member} />
+            ))}
+          </div>
+        </section>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace static hardcoded config with `useMembers` hook on the team page
- Update `TeamDisplay` to render members grouped by department with loading/error/empty states
- Add `MemberCard` component with photo (initials fallback), role, team chips, LinkedIn and email links

## Notes
- This branch depends on `feature/mentor-mentee-form-supabase` being merged first (that branch has the Notion client, member repository/service, and API route)
- `NOTION_API_KEY` and `NOTION_MEMBERS_DATABASE_ID` need to be set in Vercel before this works in production

## Test plan
- [ ] Team page shows loading spinner while fetching
- [ ] Members appear grouped by department once loaded
- [ ] Members with no department fall into "Other" group
- [ ] Member cards show photo or initials avatar, role, team chips, and social links
- [ ] Error state renders gracefully if Notion API is unavailable